### PR TITLE
Hotfix/copy arrays

### DIFF
--- a/src/Lifecycle/index.js
+++ b/src/Lifecycle/index.js
@@ -26,10 +26,6 @@ export default class Lifecycle {
   }
 
   when (name) {
-    if (!this.events.has(name)) {
-      throw new Error('Unknown lifecycle event name: ' + name)
-    }
-
-    return this.events.fetch(name)
+    return this.events.fetch(name, () => { throw new Error('Unknown lifecycle event name: ' + name) })
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,8 @@ export default class Spokes {
   }
 
   getState (key) {
-    return this.stateStack.fetch(key).pop()
+    const value = this.stateStack.fetch(key)
+    return value.length > 0 ? value.pop() : null
   }
 
   // Pub/Sub

--- a/src/index.js
+++ b/src/index.js
@@ -36,12 +36,14 @@ export default class Spokes {
   // State
 
   setState (key, value) {
-    this.stateStack.append(key, value)
+    this.stateStack.add(key, value)
     this.stateTopic.publish(key, value)
   }
 
   getState (key) {
-    return this.stateStack.fetch(key).pop()
+    const history = this.stateStack.fetch(key)
+    // get the last value that was set
+    return history.length ? history[history.length - 1] : null
   }
 
   // Pub/Sub

--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,7 @@ export default class Spokes {
   }
 
   getState (key) {
-    const history = this.stateStack.fetch(key)
-    // get the last value that was set
-    return history.length ? history[history.length - 1] : null
+    return this.stateStack.fetch(key).pop()
   }
 
   // Pub/Sub

--- a/src/lib/List.js
+++ b/src/lib/List.js
@@ -2,17 +2,20 @@ export default class List {
   keys = [];
   values = [];
 
+  index (key) {
+    return this.keys.indexOf(key)
+  }
+
   has (key) {
-    return this.keys.indexOf(key) !== -1
+    return this.index(key) !== -1
   }
 
   pairs () {
-    const values = this.values
-    return this.keys.map((key, index) => [key, values[index]])
+    return this.keys.map((key, index) => [key, this.values[index]])
   }
 
   add (key, value) {
-    const index = this.keys.indexOf(key)
+    const index = this.index(key)
 
     if (index !== -1) {
       this.values[index] = value
@@ -24,13 +27,29 @@ export default class List {
     return value
   }
 
+  remove (key) {
+    const index = this.index(key)
+
+    // remove the existing value history before appending
+    if (index === -1) {
+      return null
+    }
+
+    const value = this.fetch(key)
+
+    this.keys.splice(index, 1)
+    this.values.splice(index, 1)
+
+    return value
+  }
+
   fetch (key) {
-    const index = this.keys.indexOf(key)
+    const index = this.index(key)
 
     if (index !== -1) {
       return this.values[index]
     } else {
-      return []
+      return null
     }
   }
 

--- a/src/lib/List.js
+++ b/src/lib/List.js
@@ -43,13 +43,13 @@ export default class List {
     return value
   }
 
-  fetch (key) {
+  fetch (key, fallback = null) {
     const index = this.index(key)
 
     if (index !== -1) {
       return this.values[index]
     } else {
-      return null
+      return typeof fallback === 'function' ? fallback(key) : fallback
     }
   }
 

--- a/src/lib/ValueStack.js
+++ b/src/lib/ValueStack.js
@@ -1,30 +1,35 @@
 import List from './List'
 
+function copy (array) {
+  return array ? array.slice() : []
+}
+
 /*
     Appends values rather than  overwriting
 */
 export default class ValueStack extends List {
-  add (key, value) {
-    const index = this.keys.indexOf(key)
-
-    if (index !== -1) {
-      this.keys.splice(index, 1)
-      this.values.splice(index, 1)
-    }
-
-    return this.append(key, value)
+  pairs () {
+    return super.pairs().map(([key, value]) => [key, copy(value)])
   }
 
-  append (key, value) {
-    var index = this.keys.indexOf(key)
+  add (key, value) {
+    let values
 
-    if (index === -1) {
-      this.keys.push(key)
-      index = this.values.push([value]) - 1
+    if (this.has(key)) {
+      values = this.fetch(key)
+      values.push(value)
     } else {
-      this.values[index].push(value)
+      values = super.add(key, [value])
     }
 
-    return this.values[index].slice()
+    return copy(values)
+  }
+
+  remove (key) {
+    return copy(super.remove(key))
+  }
+
+  fetch (key) {
+    return copy(super.fetch(key))
   }
 }

--- a/src/lib/ValueStack.js
+++ b/src/lib/ValueStack.js
@@ -13,14 +13,9 @@ export default class ValueStack extends List {
   }
 
   add (key, value) {
-    let values
+    const values = [...this.fetch(key, []), value]
 
-    if (this.has(key)) {
-      values = this.fetch(key)
-      values.push(value)
-    } else {
-      values = super.add(key, [value])
-    }
+    super.add(key, values)
 
     return copy(values)
   }
@@ -29,7 +24,7 @@ export default class ValueStack extends List {
     return copy(super.remove(key))
   }
 
-  fetch (key) {
-    return copy(super.fetch(key))
+  fetch (key, fallback = null) {
+    return copy(super.fetch(key, fallback))
   }
 }

--- a/src/parseQueryString.js
+++ b/src/parseQueryString.js
@@ -7,7 +7,7 @@ export default function parseQueryString (querystring) {
 
   querystring.replace(/^\?*/, '')
     .replace(/(?:([^=&]+)(?:=([^&]*))?)/g, function (substring, key, value, index, string) {
-      result.append(decode(key), decode(value))
+      result.add(decode(key), decode(value))
     })
 
   return result

--- a/src/pubsub/Broker.js
+++ b/src/pubsub/Broker.js
@@ -33,14 +33,6 @@ export default class Broker {
   }
 
   topic (topicName) {
-    var topic
-
-    if (this.topics.has(topicName)) {
-      topic = this.topics.fetch(topicName)
-    } else {
-      topic = this.registerTopic(topicName, { keepHistory: this.keepHistory })
-    }
-
-    return topic
+    return this.topics.fetch(topicName, () => this.registerTopic(topicName, { keepHistory: this.keepHistory }))
   }
 }


### PR DESCRIPTION
* Fixes copying returned value "stack" arrays so mutations to those arrays don't  affect internal  state
* Use `add` instead of `append` for `ValueStack`
* Added `remove` to `List`
* Added default  value/callback  to `fetch` on `List` and `ValueStack`